### PR TITLE
feat(doh): accept DoH requests from edge-gateway

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,6 +197,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -275,6 +281,20 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -626,6 +646,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
@@ -893,7 +919,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -965,7 +991,7 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.16.1",
  "portable-atomic",
  "thiserror 2.0.18",
 ]
@@ -1036,7 +1062,7 @@ version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1500,7 +1526,7 @@ checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
 dependencies = [
  "bitflags 2.10.0",
  "compact_str",
- "hashbrown",
+ "hashbrown 0.16.1",
  "indoc",
  "itertools",
  "kasuari",
@@ -1551,7 +1577,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
 dependencies = [
  "bitflags 2.10.0",
- "hashbrown",
+ "hashbrown 0.16.1",
  "indoc",
  "instability",
  "itertools",
@@ -1736,9 +1762,14 @@ name = "scloud-dns"
 version = "0.2.3"
 dependencies = [
  "anyhow",
+ "base64",
  "bytes",
  "crossterm",
+ "dashmap",
  "futures-util",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "once_cell",
  "rand 0.9.2",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,5 +28,11 @@ bytes = { version = "1.11.1", features = ["serde"] }
 once_cell = "1.21.3"
 socket2 = "0.6.2"
 
+hyper = { version = "1", features = ["server", "http1", "http2"] }
+hyper-util = { version = "0.1", features = ["tokio", "server", "server-auto"] }
+http-body-util = "0.1"
+dashmap = "6"
+base64 = "0.22"
+
 [dev-dependencies]
 wiremock = "0.6"

--- a/config/config.json
+++ b/config/config.json
@@ -14,6 +14,7 @@
   },
   "workers": {
     "tcp_acceptor": 4,
+    "doh_acceptor": 1,
     "decoder": 4,
     "query_dispatcher": 1,
     "cache_lookup": 3,
@@ -108,9 +109,10 @@
   ],
   "doh": {
     "enabled": true,
-    "bind": "0.0.0.0:443",
-    "tls_cert_path": "/etc/scloud/certs/doh.crt",
-    "tls_key_path": "/etc/scloud/certs/doh.key",
+    "bind": "0.0.0.0:8053",
+    "terminate_tls": false,
+    "tls_cert_path": "",
+    "tls_key_path": "",
     "paths": [
       "/dns-query"
     ],

--- a/src/config.rs
+++ b/src/config.rs
@@ -414,7 +414,6 @@ impl Default for Config {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ServerConfig {
-    pub instance_id: String,
     pub name: String,
     pub version: String,
     pub environment: String,
@@ -433,9 +432,8 @@ pub struct ServerConfig {
 impl Default for ServerConfig {
     fn default() -> Self {
         ServerConfig {
-            instance_id: "default".to_string(),
             name: "scloud-dns".to_string(),
-            version: std::env::var("CARGO_PKG_VERSION").unwrap().to_string(),
+            version: "none".to_string(),
             environment: "production".to_string(),
             max_concurrent_requests: 5000,
             graceful_shutdown_timeout_secs: 15,

--- a/src/config.rs
+++ b/src/config.rs
@@ -162,28 +162,30 @@ impl Config {
         }
 
         if self.doh.enabled {
-            if self
-                .doh
-                .tls_cert_path
-                .as_deref()
-                .unwrap_or("")
-                .trim()
-                .is_empty()
-            {
-                return Err(SCloudException::SCLOUD_CONFIG_TLS_MISSING_CERT);
-            }
-            if self
-                .doh
-                .tls_key_path
-                .as_deref()
-                .unwrap_or("")
-                .trim()
-                .is_empty()
-            {
-                return Err(SCloudException::SCLOUD_CONFIG_TLS_MISSING_KEY);
-            }
             if self.doh.paths.is_empty() {
                 return Err(SCloudException::SCLOUD_CONFIG_INVALID_DOH);
+            }
+            if self.doh.terminate_tls {
+                if self
+                    .doh
+                    .tls_cert_path
+                    .as_deref()
+                    .unwrap_or("")
+                    .trim()
+                    .is_empty()
+                {
+                    return Err(SCloudException::SCLOUD_CONFIG_TLS_MISSING_CERT);
+                }
+                if self
+                    .doh
+                    .tls_key_path
+                    .as_deref()
+                    .unwrap_or("")
+                    .trim()
+                    .is_empty()
+                {
+                    return Err(SCloudException::SCLOUD_CONFIG_TLS_MISSING_KEY);
+                }
             }
         }
 
@@ -412,6 +414,7 @@ impl Default for Config {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ServerConfig {
+    pub instance_id: String,
     pub name: String,
     pub version: String,
     pub environment: String,
@@ -430,8 +433,9 @@ pub struct ServerConfig {
 impl Default for ServerConfig {
     fn default() -> Self {
         ServerConfig {
+            instance_id: "default".to_string(),
             name: "scloud-dns".to_string(),
-            version: "none".to_string(),
+            version: std::env::var("CARGO_PKG_VERSION").unwrap().to_string(),
             environment: "production".to_string(),
             max_concurrent_requests: 5000,
             graceful_shutdown_timeout_secs: 15,
@@ -448,6 +452,8 @@ impl Default for ServerConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorkersConfig {
     pub tcp_acceptor: u16,
+    #[serde(default)]
+    pub doh_acceptor: u16,
     pub decoder: u16,
     pub query_dispatcher: u16,
     pub cache_lookup: u16,
@@ -464,6 +470,7 @@ impl Default for WorkersConfig {
     fn default() -> Self {
         WorkersConfig {
             tcp_acceptor: 1,
+            doh_acceptor: 1,
             decoder: 5,
             query_dispatcher: 3,
             cache_lookup: 3,
@@ -652,6 +659,8 @@ pub struct DohConfig {
     pub enabled: bool,
     pub bind: String,
     #[serde(default)]
+    pub terminate_tls: bool,
+    #[serde(default)]
     pub tls_cert_path: Option<String>,
     #[serde(default)]
     pub tls_key_path: Option<String>,
@@ -665,7 +674,8 @@ impl Default for DohConfig {
     fn default() -> Self {
         DohConfig {
             enabled: false,
-            bind: "0.0.0.0:443".to_string(),
+            bind: "0.0.0.0:8053".to_string(),
+            terminate_tls: false,
             tls_cert_path: None,
             tls_key_path: None,
             paths: vec!["/dns-query".to_string()],

--- a/src/dns/tests/config.rs
+++ b/src/dns/tests/config.rs
@@ -95,7 +95,8 @@ mod tests {
     fn test_doh_config_defaults() {
         let doh = DohConfig::default();
         assert_eq!(doh.enabled, false);
-        assert_eq!(doh.bind, "0.0.0.0:443");
+        assert_eq!(doh.bind, "0.0.0.0:8053");
+        assert_eq!(doh.terminate_tls, false);
         assert_eq!(doh.paths, vec!["/dns-query"]);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,8 +46,9 @@ async fn main() -> Result<(), SCloudException> {
 
     let gate = Arc::new(StartGate::new(1));
 
-    let worker_specs: [(WorkerType, u16); 10] = [
+    let worker_specs: [(WorkerType, u16); 11] = [
         (WorkerType::TCP_ACCEPTOR, config.workers.tcp_acceptor),
+        (WorkerType::DOH_ACCEPTOR, config.workers.doh_acceptor),
         (
             WorkerType::QUERY_DISPATCHER,
             config.workers.query_dispatcher,

--- a/src/workers/manager/channels_generation.rs
+++ b/src/workers/manager/channels_generation.rs
@@ -1,4 +1,3 @@
-
 use crate::exceptions::SCloudException;
 use crate::workers::{SCloudWorker, WorkerType};
 use std::collections::HashMap;
@@ -23,6 +22,7 @@ pub(crate) async fn generate_channels(
             WorkerType::CACHE_JANITOR => "cache-janitor",
             WorkerType::METRICS => "metrics",
             WorkerType::TCP_ACCEPTOR => "tcp-acceptor",
+            WorkerType::DOH_ACCEPTOR => "doh-acceptor",
             WorkerType::NONE => "none",
         };
         wl.entry(key).or_insert_with(Vec::new).push(Arc::clone(&w));
@@ -30,6 +30,7 @@ pub(crate) async fn generate_channels(
 
     let default_worker = vec![Arc::new(SCloudWorker::new(WorkerType::NONE)?)];
     let tcp_acceptor = wl.get("tcp-acceptor").unwrap_or(&default_worker);
+    let doh_acceptor = wl.get("doh-acceptor").cloned();
     let decoder = wl.get("decoder").unwrap_or(&default_worker);
     let query_dispatcher = wl.get("query-dispatcher").unwrap_or(&default_worker);
     let cache_lookup = wl.get("cache-lookup").unwrap_or(&default_worker);
@@ -58,6 +59,9 @@ pub(crate) async fn generate_channels(
     }
 
     wire(tcp_acceptor, decoder, 1024).await;
+    if let Some(doh) = doh_acceptor.as_deref() {
+        wire(doh, decoder, 1024).await;
+    }
     wire(decoder, cache_lookup, 1024).await;
     wire(cache_lookup, cache_writers, 1024).await; // tx[0] = miss path
     wire(cache_lookup, query_dispatcher, 1024).await; // tx[1] = hit path

--- a/src/workers/mod.rs
+++ b/src/workers/mod.rs
@@ -10,6 +10,7 @@ use tokio::sync::{Mutex, MutexGuard, Semaphore, mpsc};
 
 pub(crate) mod manager;
 pub(crate) mod queue;
+pub(crate) mod reply_registry;
 pub(crate) mod task;
 pub(crate) mod tests;
 pub(crate) mod types;
@@ -154,6 +155,11 @@ impl SCloudWorker {
                 self.clone().set_state(WorkerState::IDLE);
                 let tx = self.get_dns_tx().await?;
                 types::tcp_acceptor::run_dns_tcp_acceptor(self.clone(), tx).await?;
+            }
+            WorkerType::DOH_ACCEPTOR => {
+                self.clone().set_state(WorkerState::IDLE);
+                let tx = self.get_dns_tx().await?;
+                types::doh_acceptor::run_dns_doh_acceptor(self.clone(), tx).await?;
             }
             _ => {}
         }
@@ -449,6 +455,7 @@ pub enum WorkerType {
 
     METRICS = 10,
     TCP_ACCEPTOR = 11,
+    DOH_ACCEPTOR = 12,
 }
 
 impl TryFrom<u8> for WorkerType {
@@ -468,6 +475,7 @@ impl TryFrom<u8> for WorkerType {
             9 => WorkerType::CACHE_JANITOR,
             10 => WorkerType::METRICS,
             11 => WorkerType::TCP_ACCEPTOR,
+            12 => WorkerType::DOH_ACCEPTOR,
             99 => WorkerType::NONE,
             // TODO: return an SCloudException
             _ => return Err(()),

--- a/src/workers/reply_registry.rs
+++ b/src/workers/reply_registry.rs
@@ -1,0 +1,23 @@
+use bytes::Bytes;
+use dashmap::DashMap;
+use once_cell::sync::Lazy;
+use tokio::sync::oneshot;
+use uuid::Uuid;
+
+pub const REPLY_TAG_DOH: &str = "doh";
+
+static REGISTRY: Lazy<DashMap<Uuid, oneshot::Sender<Bytes>>> = Lazy::new(DashMap::new);
+
+pub fn register(task_id: Uuid) -> oneshot::Receiver<Bytes> {
+    let (tx, rx) = oneshot::channel();
+    REGISTRY.insert(task_id, tx);
+    rx
+}
+
+pub fn take(task_id: &Uuid) -> Option<oneshot::Sender<Bytes>> {
+    REGISTRY.remove(task_id).map(|(_, v)| v)
+}
+
+pub fn drop_entry(task_id: &Uuid) {
+    REGISTRY.remove(task_id);
+}

--- a/src/workers/types/doh_acceptor.rs
+++ b/src/workers/types/doh_acceptor.rs
@@ -1,0 +1,282 @@
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use bytes::Bytes;
+use http_body_util::{BodyExt, Full};
+use hyper::body::Incoming;
+use hyper::service::service_fn;
+use hyper::{Method, Request, Response, StatusCode};
+use hyper_util::rt::{TokioExecutor, TokioIo};
+use hyper_util::server::conn::auto::Builder;
+use std::collections::HashSet;
+use std::net::SocketAddr;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+use tokio::net::TcpListener;
+use tokio::sync::mpsc;
+use tokio::time::timeout;
+
+use crate::config::Config;
+use crate::exceptions::SCloudException;
+use crate::utils;
+use crate::workers::task::{InFlightTask, SCloudWorkerTask};
+use crate::workers::{SCloudWorker, WorkerType, reply_registry};
+use crate::{log_debug, log_error, log_info};
+
+const MAX_DNS_MESSAGE_BYTES: usize = 65_535;
+const REPLY_TIMEOUT_SECS: u64 = 10;
+const DNS_MESSAGE_MIME: &str = "application/dns-message";
+
+#[derive(Clone)]
+struct DohHandlerCtx {
+    worker: Arc<SCloudWorker>,
+    tx: Vec<mpsc::Sender<InFlightTask>>,
+    paths: Arc<HashSet<String>>,
+    allowed_origins: Arc<HashSet<String>>,
+}
+
+pub async fn run_dns_doh_acceptor(
+    worker: Arc<SCloudWorker>,
+    tx: Vec<mpsc::Sender<InFlightTask>>,
+) -> Result<(), SCloudException> {
+    if tx.is_empty() {
+        return Err(SCloudException::SCLOUD_WORKER_TX_NOT_SET);
+    }
+
+    let cfg = Config::from_file(Path::new("./config/config.json"))?;
+    if !cfg.doh.enabled {
+        log_info!("DoH disabled in config, acceptor idle");
+        futures_util::future::pending::<()>().await;
+        return Ok(());
+    }
+
+    let bind_addr: SocketAddr = cfg
+        .doh
+        .bind
+        .parse()
+        .map_err(|_| SCloudException::SCLOUD_CONFIG_IMPOSSIBLE_TO_PARSE_ADDR)?;
+
+    let listener = TcpListener::bind(bind_addr)
+        .await
+        .map_err(|_| SCloudException::SCLOUD_WORKER_LISTENER_BIND_FAILED)?;
+
+    log_info!("DoH acceptor listening on http://{}", bind_addr);
+
+    let ctx = DohHandlerCtx {
+        worker: worker.clone(),
+        tx,
+        paths: Arc::new(cfg.doh.paths.into_iter().collect()),
+        allowed_origins: Arc::new(cfg.doh.allowed_origins.into_iter().collect()),
+    };
+
+    loop {
+        let (stream, peer) = match listener.accept().await {
+            Ok(v) => v,
+            Err(e) => {
+                log_error!("doh accept failed: {}", e);
+                continue;
+            }
+        };
+        let io = TokioIo::new(stream);
+        let ctx = ctx.clone();
+
+        tokio::spawn(async move {
+            let svc = service_fn(move |req| handle_request(ctx.clone(), peer, req));
+            if let Err(e) = Builder::new(TokioExecutor::new())
+                .serve_connection(io, svc)
+                .await
+            {
+                log_debug!("doh connection from {} ended: {}", peer, e);
+            }
+        });
+    }
+}
+
+async fn handle_request(
+    ctx: DohHandlerCtx,
+    peer: SocketAddr,
+    req: Request<Incoming>,
+) -> Result<Response<Full<Bytes>>, std::convert::Infallible> {
+    let method = req.method().clone();
+    let uri_path = req.uri().path().to_string();
+    let origin = req
+        .headers()
+        .get("origin")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+
+    if method == Method::OPTIONS {
+        return Ok(cors_preflight(&ctx, origin.as_deref()));
+    }
+
+    if !ctx.paths.contains(&uri_path) {
+        return Ok(simple(StatusCode::NOT_FOUND, "unknown doh path"));
+    }
+
+    let wire = match method {
+        Method::GET => match extract_get_dns(&req) {
+            Ok(b) => b,
+            Err(resp) => return Ok(resp),
+        },
+        Method::POST => match extract_post_dns(req).await {
+            Ok(b) => b,
+            Err(resp) => return Ok(resp),
+        },
+        _ => return Ok(simple(StatusCode::METHOD_NOT_ALLOWED, "method not allowed")),
+    };
+
+    if wire.is_empty() || wire.len() > MAX_DNS_MESSAGE_BYTES {
+        return Ok(simple(StatusCode::BAD_REQUEST, "empty or oversize dns body"));
+    }
+
+    let reply = match dispatch_and_wait(&ctx, peer, wire).await {
+        Ok(b) => b,
+        Err(status) => return Ok(simple(status, "dispatch failed")),
+    };
+
+    let mut resp = Response::builder()
+        .status(StatusCode::OK)
+        .header("Content-Type", DNS_MESSAGE_MIME)
+        .header("Cache-Control", "no-store")
+        .body(Full::new(reply))
+        .unwrap();
+    apply_cors(&mut resp, &ctx, origin.as_deref());
+    Ok(resp)
+}
+
+fn extract_get_dns(req: &Request<Incoming>) -> Result<Bytes, Response<Full<Bytes>>> {
+    let q = req.uri().query().unwrap_or("");
+    let mut dns_param: Option<&str> = None;
+    for pair in q.split('&') {
+        if let Some(v) = pair.strip_prefix("dns=") {
+            dns_param = Some(v);
+            break;
+        }
+    }
+    let dns_b64 = dns_param
+        .ok_or_else(|| simple(StatusCode::BAD_REQUEST, "missing dns query parameter"))?;
+    URL_SAFE_NO_PAD
+        .decode(dns_b64)
+        .map(Bytes::from)
+        .map_err(|_| simple(StatusCode::BAD_REQUEST, "invalid base64url dns parameter"))
+}
+
+async fn extract_post_dns(
+    req: Request<Incoming>,
+) -> Result<Bytes, Response<Full<Bytes>>> {
+    let ct_ok = req
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .map(|v| v.starts_with(DNS_MESSAGE_MIME))
+        .unwrap_or(false);
+    if !ct_ok {
+        return Err(simple(
+            StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            "expected application/dns-message",
+        ));
+    }
+    let body = req
+        .into_body()
+        .collect()
+        .await
+        .map_err(|_| simple(StatusCode::BAD_REQUEST, "failed reading body"))?
+        .to_bytes();
+    Ok(body)
+}
+
+async fn dispatch_and_wait(
+    ctx: &DohHandlerCtx,
+    peer: SocketAddr,
+    wire: Bytes,
+) -> Result<Bytes, StatusCode> {
+    let permit = ctx
+        .worker
+        .in_flight_sem
+        .clone()
+        .try_acquire_owned()
+        .map_err(|_| StatusCode::TOO_MANY_REQUESTS)?;
+
+    let task_id = utils::uuid::generate_uuid();
+    let task = SCloudWorkerTask {
+        task_id,
+        for_type: WorkerType::DOH_ACCEPTOR,
+        for_who: peer,
+        payload: wire,
+        attempts: 0,
+        max_attempts: 0,
+        created_at: SystemTime::now(),
+        deadline_timeout: None,
+        priority: 0,
+        reply_to: Some(reply_registry::REPLY_TAG_DOH.to_string()),
+        correlation_id: None,
+    };
+    let in_flight = InFlightTask { task, _permit: permit };
+
+    let rx = reply_registry::register(task_id);
+
+    if !forward_task(in_flight, &ctx.tx).await {
+        reply_registry::drop_entry(&task_id);
+        return Err(StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    match timeout(Duration::from_secs(REPLY_TIMEOUT_SECS), rx).await {
+        Ok(Ok(bytes)) => Ok(bytes),
+        _ => {
+            reply_registry::drop_entry(&task_id);
+            Err(StatusCode::GATEWAY_TIMEOUT)
+        }
+    }
+}
+
+async fn forward_task(task: InFlightTask, tx: &[mpsc::Sender<InFlightTask>]) -> bool {
+    let mut current = Some(task);
+    for tx_channel in tx.iter() {
+        match tx_channel.try_send(current.take().unwrap()) {
+            Ok(_) => return true,
+            Err(mpsc::error::TrySendError::Full(returned)) => {
+                current = Some(returned);
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => return false,
+        }
+    }
+    if let Some(unsent) = current {
+        if let Some(first) = tx.first() {
+            return first.send(unsent).await.is_ok();
+        }
+    }
+    true
+}
+
+fn simple(status: StatusCode, msg: &str) -> Response<Full<Bytes>> {
+    Response::builder()
+        .status(status)
+        .header("Content-Type", "text/plain; charset=utf-8")
+        .body(Full::new(Bytes::copy_from_slice(msg.as_bytes())))
+        .unwrap()
+}
+
+fn cors_preflight(ctx: &DohHandlerCtx, origin: Option<&str>) -> Response<Full<Bytes>> {
+    let mut resp = Response::builder()
+        .status(StatusCode::NO_CONTENT)
+        .header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+        .header("Access-Control-Allow-Headers", "Content-Type, Accept")
+        .header("Access-Control-Max-Age", "600")
+        .body(Full::new(Bytes::new()))
+        .unwrap();
+    apply_cors(&mut resp, ctx, origin);
+    resp
+}
+
+fn apply_cors(resp: &mut Response<Full<Bytes>>, ctx: &DohHandlerCtx, origin: Option<&str>) {
+    if ctx.allowed_origins.is_empty() {
+        return;
+    }
+    if let Some(o) = origin {
+        if ctx.allowed_origins.contains(o) {
+            if let Ok(v) = o.parse() {
+                resp.headers_mut().insert("Access-Control-Allow-Origin", v);
+            }
+        }
+    }
+}

--- a/src/workers/types/mod.rs
+++ b/src/workers/types/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod cache_janitor;
 pub(crate) mod cache_lookup;
 pub(crate) mod cache_writer;
 pub(crate) mod decoder;
+pub(crate) mod doh_acceptor;
 pub(crate) mod encoder;
 pub(crate) mod listener;
 pub(crate) mod metrics;

--- a/src/workers/types/sender.rs
+++ b/src/workers/types/sender.rs
@@ -1,6 +1,8 @@
 use crate::exceptions::SCloudException;
 use crate::workers::SCloudWorker;
+use crate::workers::reply_registry;
 use crate::workers::task::InFlightTask;
+use crate::log_debug;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 
@@ -8,10 +10,26 @@ pub async fn run_dns_sender(
     worker: Arc<SCloudWorker>,
     mut rx: Vec<mpsc::Receiver<InFlightTask>>,
 ) -> Result<(), SCloudException> {
+    let _ = worker;
     loop {
         for rx_channel in rx.iter_mut() {
             while let Some(msg) = rx_channel.recv().await {
-                // need to send back to the user in task::SCloudWorkerTask.for_who
+                let tag = msg.task.reply_to.as_deref().unwrap_or("");
+                match tag {
+                    reply_registry::REPLY_TAG_DOH => {
+                        if let Some(sender) = reply_registry::take(&msg.task.task_id) {
+                            let _ = sender.send(msg.task.payload.clone());
+                        } else {
+                            log_debug!(
+                                "sender: no registered reply channel for task {}",
+                                msg.task.task_id
+                            );
+                        }
+                    }
+                    _ => {
+                        // TODO: UDP / TCP reply path — not implemented yet.
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

Adds DNS-over-HTTPS (RFC 8484) receive/respond support to scloud-dns so the edge-gateway can proxy `/dns-query` requests into the existing worker pipeline.            

- New `DOH_ACCEPTOR` worker type serving plain HTTP/1.1 + h2c on `config.doh.bind` (default `0.0.0.0:8053`). TLS is terminated upstream by `2scloud-edge-gateway`, so no cert material is needed here (`doh.terminate_tls = false` by default).
- Per-request reply-channel registry (`DashMap<Uuid, oneshot::Sender<Bytes>>`) so the HTTP handler can `await` the encoded DNS response without relying on   `SocketAddr`-based routing.
- `sender.rs` routes replies tagged `doh` back through the registry; UDP/TCP reply paths remain stubbed.
- Accepts both `GET ?dns=<base64url>` and `POST application/dns-message`, honors `doh.paths` and `doh.allowed_origins` (CORS), enforces a 10s per-request    timeout and a 65 KiB size cap. 
- Worker count pluggable via `config.workers.doh_acceptor` (serde-defaulted to 1).                                            
- Relaxed DoH validation: cert/key are only required when `doh.terminate_tls = true`.

## Companion change

The edge-gateway side lives in `2scloud/2scloud-edge-gateway` — it adds a `[doh]` config section and a Fiber proxy route that forwards `/dns-query` to `http://scloud-dns:8053`. That PR should land together with this one.

## Known gaps (out of scope)

- Pipeline stages (decoder → resolver → encoder) still passthrough the payload, so the HTTP reply currently echoes the request until those stages emit real DNS responses. `sender.rs` routing is ready the moment the encoder produces real bytes.
- UDP/TCP reply paths in `sender.rs` still marked \`TODO\`.
- No in-process TLS termination path yet (would require rustls wiring when \`terminate_tls = true\`).

## Test plan

- [ ] \`cargo build\` succeeds
- [ ] \`cargo test\` passes (no new tests added yet)
- [ ] Local smoke: start scloud-dns, \`curl -H 'accept: application/dns-message' 'http://127.0.0.1:8053/dns-query?dns=<b64url-query>'\` returns \`application/dns-message\`
- [ ] Behind edge-gateway: same request to the gateway proxies through and returns the DNS reply
- [ ] \`doh.enabled = false\` keeps the acceptor idle, no port bind